### PR TITLE
Editable pip install in devcontainer

### DIFF
--- a/.devcontainer/.postcreate_setup.sh
+++ b/.devcontainer/.postcreate_setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Set git to not change file permissions
+git config core.fileMode false
+
+# Make editable install of JAIL package
+pip install -e /workspaces/jail

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -19,16 +19,30 @@ RUN mamba install --yes \
     'h5py' \
     'ipykernel' \
     'ipympl' \
-    'matplotlib' \
-    'numpy' \
     'pip' \
     'pre-commit' \
     'ruff' \
-    'scipy' \
     && \
     mamba clean --all -f -y
 
-RUN pip install --no-cache-dir \
-    --extra-index-url https://download.pytorch.org/whl/cpu \
-    finufft \
-    torch
+# Install finufft and torch
+# RUN pip install --no-cache-dir \
+#     --extra-index-url https://download.pytorch.org/whl/cpu
+#     finufft \
+#     torch
+
+# Add non-root user
+ARG USERNAME=nonroot
+RUN groupadd --gid 1000 $USERNAME && \
+    useradd --uid 1000 --gid 1000 -m $USERNAME
+
+# Make sure to reflect new user in PATH
+ENV PATH="/home/${USERNAME}/.local/bin:${PATH}"
+
+# Copy the .postcreate_setup.sh script into the container
+ADD .postcreate_setup.sh /workspaces/jail/.devcontainer/.postcreate_setup.sh
+
+# Change permissions of .postcreate_setup.sh to make it executable
+RUN chmod +x /workspaces/jail/.devcontainer/.postcreate_setup.sh
+
+USER $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,7 +17,7 @@
         }
       }
     },
-    "remoteUser": "root",
+    "remoteUser": "nonroot",
     "updateRemoteUserUID": true,
     "runArgs": [
         "--userns=keep-id"
@@ -25,5 +25,5 @@
     "mounts": [
       "source=${localEnv:HOME}${localEnv:USERPROFILE},target=/host-home-folder,type=bind"
     ],
-    "postCreateCommand": "git config core.fileMode false"
+    "postCreateCommand": "sh /workspaces/jail/.devcontainer/.postcreate_setup.sh"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,10 @@ dependencies = [
     "torch>=2.0.0",
     "finufft",
     "ismrmrd",
-    "threadpoolctl"
+    "threadpoolctl",
+    "scipy",
+    "numpy",
+    "matplotlib",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Make editable pip install of package inside devcontainer.

- Transfered all dependencies from dockerfile to pyprojext.toml
- Changed user from root to non root
- Created shell script to run multiple PostCreateCommands

TO DISCUSS:
All path are hard coded. I am not sure, how to do otherwise.